### PR TITLE
Support file not found for GCS

### DIFF
--- a/core/src/test/scala/blobstore/AbstractStoreTest.scala
+++ b/core/src/test/scala/blobstore/AbstractStoreTest.scala
@@ -105,7 +105,7 @@ trait AbstractStoreTest extends FlatSpec with MustMatchers with BeforeAndAfterAl
 
     store.listAll(dir).unsafeRunSync().isEmpty must be(true)
   }
-  
+
   // We've had some bugs involving directories at the root level, since it is a bit of an edge case.
   // Worth noting that that most of these tests operate on files that are in nested directories, avoiding
   // any problems that there might be with operating on a root level file/directory.
@@ -118,7 +118,7 @@ trait AbstractStoreTest extends FlatSpec with MustMatchers with BeforeAndAfterAl
       .map(writeFile(store, rootDir))
 
     val exp = paths.map(p => s"${p.key}").toSet
-    
+
     // Not doing equals comparison because this directory contains files from other tests.
     // Also, some stores will prepend a "/" before the filenames. Doing a string comparison to ignore this detail for now.
     val pathsListed = store.listAll(rootDir).unsafeRunSync().map(_.key).toSet.toString()
@@ -287,7 +287,7 @@ trait AbstractStoreTest extends FlatSpec with MustMatchers with BeforeAndAfterAl
     store.list(srcDir)
       .compile.drain.unsafeRunSync().isEmpty must be(true)
   }
-  
+
   it should "succeed on remove when path does not exist" in {
     val dir = dirPath("remove-nonexistent-path")
     val path = dir / "no-file.txt"
@@ -307,6 +307,14 @@ trait AbstractStoreTest extends FlatSpec with MustMatchers with BeforeAndAfterAl
       res <- store.getContents(path)
       _ <- store.remove(path)
     } yield res must be(exp)
+
+    test.unsafeRunSync()
+  }
+
+  it should "return failed stream when getting non-existing file" in {
+    val test = for {
+      res <- store.get(dirPath("foo") / "doesnt-exists.txt").attempt.compile.lastOrError
+    } yield res mustBe a[Left[_, _]]
 
     test.unsafeRunSync()
   }

--- a/gcs/src/main/scala/blobstore/gcs/GcsStore.scala
+++ b/gcs/src/main/scala/blobstore/gcs/GcsStore.scala
@@ -1,13 +1,15 @@
 package blobstore.gcs
 
+import java.io.InputStream
 import java.nio.channels.Channels
 import java.time.Instant
 import java.util.Date
 
 import blobstore.{Path, Store}
 import cats.effect.{ContextShift, Sync}
+import cats.syntax.applicative._
 import com.google.api.gax.paging.Page
-import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, Storage}
+import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, Storage, StorageException}
 import com.google.cloud.storage.Storage.{BlobListOption, CopyRequest}
 import fs2.{Chunk, Sink, Stream}
 
@@ -44,8 +46,15 @@ final case class GcsStore[F[_]](storage: Storage, blockingExecutionContext: Exec
   }
 
   def get(path: Path, chunkSize: Int): fs2.Stream[F, Byte] = {
-    val is = CS.evalOn(blockingExecutionContext)(F.delay(Channels.newInputStream(storage.get(path.root, path.key).reader())))
-    fs2.io.readInputStream(is, chunkSize, blockingExecutionContext, closeAfterUse = true)
+    val readBlob = F.delay {
+      Option(storage.get(path.root, path.key)).map(blob => Channels.newInputStream(blob.reader()))
+    }
+    val is: F[Option[InputStream]] = CS.evalOn(blockingExecutionContext)(readBlob)
+
+    Stream.eval(is).flatMap {
+      case Some(is) => fs2.io.readInputStream(is.pure[F], chunkSize, blockingExecutionContext, closeAfterUse = true)
+      case None => Stream.raiseError[F](new StorageException(404, s"Object not found, $path"))
+    }
   }
 
   def put(path: Path): Sink[F, Byte] = {


### PR DESCRIPTION
Current `master` produces the following when accessing an object that doesn't exists

```
java.lang.NullPointerException: null
	at blobstore.gcs.GcsStore.$anonfun$get$1(GcsStore.scala:47)
	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:87)
```