### PR TITLE
Support SFTP paths to root or home directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ stages:
   if: "(branch = master AND type = push) OR (tag IS present)"
 
 script:
-  - docker-compose run --rm sbt ++$TRAVIS_SCALA_VERSION clean coverage "testOnly * -- -l blobstore.IntegrationTest" coverageReport
+  - docker-compose run --rm sbt -Dsbt.ci=true ++$TRAVIS_SCALA_VERSION clean coverage "testOnly * -- -l blobstore.IntegrationTest" coverageReport
   - bash <(curl -s https://codecov.io/bash) -F "scala_${TRAVIS_SCALA_VERSION//[.-]/_}"
 
 jobs:

--- a/core/src/test/scala/blobstore/AbstractStoreTest.scala
+++ b/core/src/test/scala/blobstore/AbstractStoreTest.scala
@@ -124,7 +124,7 @@ trait AbstractStoreTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
     // Not doing equals comparison because this directory contains files from other tests.
     // Also, some stores will prepend a "/" before the filenames. Doing a string comparison to ignore this detail for now.
     val pathsListed = store.listAll(rootDir).unsafeRunSync().map(_.key).toSet.toString()
-    exp.foreach(pathsListed.contains(_) must be(true))
+    exp.foreach(s => pathsListed must include(s))
 
     val io: IO[List[Unit]] = paths.map(store.remove).sequence
     io.unsafeRunSync()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,15 @@ services:
 
     command: "blob:password:::sftp_tests"
 
+  sftp-no-chroot:
+    image: atmoz/sftp
+
+    volumes:
+      - ./tmp/sftp-store-root:/home/blob
+      - ./sshd_config:/etc/ssh/sshd_config
+
+    command: "blob:password:::sftp_tests"
+
   minio:
     image: minio/minio
 
@@ -36,4 +45,5 @@ services:
 
     links:
       - sftp:sftp-container
+      - sftp-no-chroot:sftp-no-chroot
       - minio:minio-container

--- a/sftp/src/test/scala/blobstore/sftp/SftpStoreChrootTest.scala
+++ b/sftp/src/test/scala/blobstore/sftp/SftpStoreChrootTest.scala
@@ -1,0 +1,27 @@
+package blobstore.sftp
+
+import java.util.Properties
+
+import cats.effect.IO
+import com.jcraft.jsch.JSch
+
+/**
+  * sftp-container follows the default atmoz/sftp configuration and will have "/" mapped to the user's home directory
+  */
+class SftpStoreChrootTest extends AbstractSftpStoreTest {
+  override val session = IO {
+    val jsch = new JSch()
+
+    val session = jsch.getSession("blob", "sftp-container", 22)
+    session.setTimeout(10000)
+    session.setPassword("password")
+
+    val config = new Properties
+    config.put("StrictHostKeyChecking", "no")
+    session.setConfig(config)
+
+    session.connect()
+
+    session
+  }
+}

--- a/sftp/src/test/scala/blobstore/sftp/SftpStoreNoChrootTest.scala
+++ b/sftp/src/test/scala/blobstore/sftp/SftpStoreNoChrootTest.scala
@@ -1,0 +1,27 @@
+package blobstore.sftp
+
+import java.util.Properties
+
+import cats.effect.IO
+import com.jcraft.jsch.JSch
+
+/**
+  * sftp-no-chroot-container doesn't map user's home directory to "/". User's instead land in "/home/<username>/"
+  */
+class SftpStoreNoChrootTest extends AbstractSftpStoreTest {
+  override val session = IO {
+    val jsch = new JSch()
+
+    val session = jsch.getSession("blob", "sftp-no-chroot", 22)
+    session.setTimeout(10000)
+    session.setPassword("password")
+
+    val config = new Properties
+    config.put("StrictHostKeyChecking", "no")
+    session.setConfig(config)
+
+    session.connect()
+
+    session
+  }
+}

--- a/sshd_config
+++ b/sshd_config
@@ -1,0 +1,26 @@
+# This is a copy of the default sshd_config in atmoz/sftp
+# We disable ChrootDirectory and ForceCommand to cover SFTP servers configured this way.
+# With this configuration, SFTP users lands at /home/<username>/ instead of /
+
+# Secure defaults
+# See: https://stribika.github.io/2015/01/04/secure-secure-shell.html
+Protocol 2
+HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_rsa_key
+
+# Faster connection
+# See: https://github.com/atmoz/sftp/issues/11
+UseDNS no
+
+# Limited access
+PermitRootLogin no
+X11Forwarding no
+AllowTcpForwarding no
+
+# Force sftp and chroot jail
+Subsystem sftp internal-sftp
+#ForceCommand internal-sftp
+#ChrootDirectory %h
+
+# Enable this for more logs
+#LogLevel VERBOSE


### PR DESCRIPTION
This PR introduces a new test container that configures the SFTP server without the `ChrootDirectory` directive. This causes users to land in `/home/<username>/` instead of `/` (`ChrootDirectory %h` maps the user's home directory to `/`).

In order for tests to pass on both server configuration, we must support relative paths. This PR introduces that support.

**Discussion, not strictly related to PR contents**

I think the `Path` abstraction needs to be augmented or adjusted in order to fully support SFTP. It currently leaks assumptions about the underlying storage, i.e. there's always two components to paths (`root` and `key`) and there's no separation between absolute and relative paths. This doesn't hold up for SFTP stores where the following paths are all valid and pointing to different files (ref [spec#section-6](https://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-6)):

1. Absolute path `"/foo.txt"`
1. Relative to CWD path `"./foo.txt"`
1. Relative to user home path `"foo.txt"`

Since we don't surface any APIs for changing CWD, we can probably get away with assuming `CWD == user home`.

Any views on a better API is welcome. I think we should encode the fact that blobstore paths are different from filestore paths (e.g. SFTP) and introduce something like

```
sealed trait Path
object Path {
  case class BlobstorePath(scheme:String, bucketName: String, path: String) extends Path
  case class FilestorePath(path: String) extends Path
}

trait Store[F[_]] {
  type PathType
}
```