### PR TITLE
Retain information about narrowed type when doing list

### DIFF
--- a/azure/src/main/scala/blobstore/azure/AzureStore.scala
+++ b/azure/src/main/scala/blobstore/azure/AzureStore.scala
@@ -46,7 +46,8 @@ final class AzureStore[F[_]](
   extends Store[F] {
   require(numBuffers >= 2, "Number of buffers must be at least 2")
 
-  override def list(path: Path): Stream[F, Path] = listUnderlying(path, defaultTrailingSlashFiles, defaultFullMetadata)
+  override def list(path: Path): Stream[F, AzurePath] =
+    listUnderlying(path, defaultTrailingSlashFiles, defaultFullMetadata)
 
   override def get(path: Path, chunkSize: Int): Stream[F, Byte] =
     AzureStore.pathToContainerAndBlob(path) match {

--- a/box/src/main/scala/blobstore/box/BoxStore.scala
+++ b/box/src/main/scala/blobstore/box/BoxStore.scala
@@ -36,7 +36,7 @@ final class BoxStore[F[_]](
 ) extends Store[F] {
   private val rootFolder = new BoxFolder(api, rootFolderId)
 
-  override def list(path: Path): Stream[F, Path] = listUnderlying(path, Array.empty)
+  override def list(path: Path): Stream[F, BoxPath] = listUnderlying(path, Array.empty)
 
   override def get(path: Path, chunkSize: Int): Stream[F, Byte] = {
     val init: F[(OutputStream, InputStream)] = blocker.delay {

--- a/core/src/main/scala/blobstore/BasePath.scala
+++ b/core/src/main/scala/blobstore/BasePath.scala
@@ -25,7 +25,8 @@ object BasePath {
     isDir: Option[Boolean],
     lastModified: Option[Instant]
   ): BasePath = new BasePath(root, pathFromRoot, fileName, size, isDir, lastModified)
-  def fromString(s: String, forceRoot: Boolean): Option[Path] =
+
+  def fromString(s: String, forceRoot: Boolean): Option[BasePath] =
     if (s.isEmpty) Some(empty)
     else
       scala.util.Try(URI.create(s)).toOption.flatMap { uri =>
@@ -36,7 +37,7 @@ object BasePath {
         val root =
           authority.orElse(if (forceRoot) pathSegments.headOption else None)
         if ((root.isEmpty && forceRoot) || root.exists(_.isEmpty))
-          Option.empty[Path]
+          Option.empty[BasePath]
         else {
           val (pathFromRoot, fileName) = {
             val ps = if (root.isDefined && authority.isEmpty) pathSegments.drop(1) else pathSegments

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,6 @@ import blobstore.sftp.SftpStore
 import cats.effect.{Blocker, ExitCode, IO, IOApp}
 import com.jcraft.jsch.{JSch, Session}
 import software.amazon.awssdk.services.s3.S3AsyncClient
-import cats.syntax.flatMap._
 import fs2.Stream
 
 object Example extends IOApp {
@@ -71,7 +70,7 @@ object Example extends IOApp {
   val connectSftp: IO[Session] = IO {
     val jsch = new JSch()
     jsch.getSession("sftp.domain.com")
-  }.flatTap(session => IO(session.connect()))
+  }
 
   val s3Client: S3AsyncClient = S3AsyncClient.builder().build()
 
@@ -302,10 +301,7 @@ object SftpExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] = Blocker[IO].use { blocker =>
     val session: IO[Session] = IO {
       val jsch = new JSch()
-      val session = jsch.getSession("sftp.domain.com")
-      session.connect()
-
-      session
+      jsch.getSession("sftp.domain.com")
     }
 
     val store: fs2.Stream[IO, SftpStore[IO]] = SftpStore("", session, blocker)

--- a/gcs/src/main/scala/blobstore/gcs/GcsStore.scala
+++ b/gcs/src/main/scala/blobstore/gcs/GcsStore.scala
@@ -24,7 +24,7 @@ final class GcsStore[F[_]](
   CS: ContextShift[F]
 ) extends Store[F] {
 
-  override def list(path: Path): Stream[F, Path] = listUnderlying(path, defaultTrailingSlashFiles)
+  override def list(path: Path): Stream[F, GcsPath] = listUnderlying(path, defaultTrailingSlashFiles)
 
   override def get(path: Path, chunkSize: Int): Stream[F, Byte] =
     GcsStore.pathToBlobId(path) match {

--- a/s3/src/main/scala/blobstore/s3/S3Store.scala
+++ b/s3/src/main/scala/blobstore/s3/S3Store.scala
@@ -61,7 +61,8 @@ final class S3Store[F[_]](
     s"Buffer size must be at least ${S3Store.multiUploadMinimumPartSize}"
   )
 
-  override def list(path: Path): Stream[F, Path] = listUnderlying(path, defaultFullMetadata, defaultTrailingSlashFiles)
+  override def list(path: Path): Stream[F, S3Path] =
+    listUnderlying(path, defaultFullMetadata, defaultTrailingSlashFiles)
 
   override def get(path: Path, chunkSize: Int): Stream[F, Byte] = S3Store.bucketKeyMetaFromPath(path) match {
     case None => Stream.raiseError(S3Store.missingRootError(s"Unable to read '$path'"))
@@ -131,7 +132,7 @@ final class S3Store[F[_]](
       liftJavaFuture(F.delay(s3.deleteObject(req))).void
   }
 
-  def listUnderlying(path: Path, fullMetadata: Boolean, expectTrailingSlashFiles: Boolean): Stream[F, Path] =
+  def listUnderlying(path: Path, fullMetadata: Boolean, expectTrailingSlashFiles: Boolean): Stream[F, S3Path] =
     S3Store.bucketKeyMetaFromPath(path) match {
       case None => Stream.raiseError(S3Store.missingRootError(s"Unable to list '$path'"))
       case Some((bucket, key, _)) =>

--- a/sftp/src/main/scala/blobstore/sftp/SftpPath.scala
+++ b/sftp/src/main/scala/blobstore/sftp/SftpPath.scala
@@ -1,0 +1,17 @@
+package blobstore.sftp
+
+import java.time.Instant
+
+import blobstore.Path
+import cats.data.Chain
+import com.jcraft.jsch.SftpATTRS
+
+case class SftpPath(root: Option[String], fileName: Option[String], pathFromRoot: Chain[String], attributes: SftpATTRS)
+  extends Path {
+
+  override val isDir: Option[Boolean] = Option(attributes.isDir)
+
+  override val size: Option[Long] = Option(attributes.getSize)
+
+  override val lastModified: Option[Instant] = Option(attributes.getMTime.toLong).map(Instant.ofEpochSecond)
+}

--- a/sftp/src/main/scala/blobstore/sftp/SftpStore.scala
+++ b/sftp/src/main/scala/blobstore/sftp/SftpStore.scala
@@ -21,7 +21,6 @@ import cats.syntax.all._
 import cats.instances.option._
 import cats.instances.string._
 import java.io.OutputStream
-import java.time.Instant
 
 import cats.effect.{Blocker, ConcurrentEffect, ContextShift, Effect, IO, Resource}
 import cats.effect.concurrent.{MVar, Semaphore}
@@ -65,7 +64,7 @@ final class SftpStore[F[_]](
     * @param path path to list
     * @return Stream[F, Path]
     */
-  override def list(path: Path): Stream[F, Path] = {
+  override def list(path: Path): Stream[F, SftpPath] = {
 
     def entrySelector(cb: ChannelSftp#LsEntry => Unit): ChannelSftp.LsEntrySelector = (entry: ChannelSftp#LsEntry) => {
       cb(entry)
@@ -89,10 +88,8 @@ final class SftpStore[F[_]](
       val newPath =
         if (path.fileName.contains(entry.getFilename)) path
         else path / (entry.getFilename ++ (if (isDir.contains(true)) "/" else ""))
-      newPath
-        .withSize(Option(entry.getAttrs.getSize), reset = false)
-        .withIsDir(isDir, reset = false)
-        .withLastModified(Option(entry.getAttrs.getMTime.toLong).map(Instant.ofEpochSecond), reset = false)
+
+      SftpPath(newPath.root, newPath.fileName, newPath.pathFromRoot, entry.getAttrs)
     }
   }
 
@@ -184,7 +181,14 @@ object SftpStore {
       Stream.raiseError[F](new IllegalArgumentException(s"maxChannels must be >= 1"))
     } else
       for {
-        session   <- Stream.bracket(fa)(session => blocker.delay(session.disconnect()))
+        session <- {
+          val attemptConnect = fa.flatTap { session =>
+            blocker.delay(session.connect()).recover {
+              case e: JSchException if e.getMessage == "session is already connected" => ()
+            }
+          }
+          Stream.bracket(attemptConnect)(session => blocker.delay(session.disconnect()))
+        }
         semaphore <- Stream.eval(maxChannels.traverse(Semaphore.apply[F]))
         mVar <- Stream.bracket(MVar.empty[F, ChannelSftp])(mVar =>
           mVar.tryTake.flatMap(_.fold(().pure[F])(closeChannel[F](semaphore, blocker)))

--- a/sftp/src/test/scala/blobstore/sftp/SftpStoreNoChrootTest.scala
+++ b/sftp/src/test/scala/blobstore/sftp/SftpStoreNoChrootTest.scala
@@ -22,14 +22,12 @@ class SftpStoreNoChrootTest extends AbstractSftpStoreTest {
     val config = new Properties
     config.put("StrictHostKeyChecking", "no")
     session.setConfig(config)
-
-    session.connect()
-
-    session
+    session // Let the store connect this session
   }
 
   it should "honor absRoot on put" in {
     val s = session.unsafeRunSync()
+    s.connect(10000)
 
     val store: Store[IO] =
       new SftpStore[IO](s"/home/blob/", s, blocker, mVar, None, 10000)


### PR DESCRIPTION
* Retain knowledge about the narrowed type when doing `.list`
* Introduce SftpPath for capturing sftp path attributes
* Connect Sftp `Session` if client haven't connected it.