### PR TITLE
Property based test for Azure put/get to verify symmetric results

### DIFF
--- a/azure/src/test/scala/blobstore/azure/AzureStoreTest.scala
+++ b/azure/src/test/scala/blobstore/azure/AzureStoreTest.scala
@@ -16,8 +16,8 @@ import org.scalatestplus.scalacheck.Checkers
 
 class AzureStoreTest extends AbstractStoreTest[Bucket, AzureBlob] with Inside with Checkers {
 
-
-  override implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration().copy(minSuccessful = 1000)
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration().copy(minSuccessful = 1000)
   val container: GenericContainer = GenericContainer(
     dockerImage = "mcr.microsoft.com/azure-storage/azurite",
     exposedPorts = List(10000),
@@ -57,13 +57,13 @@ class AzureStoreTest extends AbstractStoreTest[Bucket, AzureBlob] with Inside wi
 
   it should "put and get should yield symmetric results" in {
     check[List[Byte], Int, Boolean] { case (bytes: List[Byte], n: Int) =>
-      val dir = dirUrl("read-write")
+      val dir      = dirUrl("read-write")
       val filePath = dir / s"file-$n"
-      val blob = Stream.emits(bytes)
+      val blob     = Stream.emits(bytes)
 
       def prg =
         for {
-          _ <- blob.through(store.put(filePath)).compile.drain
+          _        <- blob.through(store.put(filePath)).compile.drain
           contents <- store.get(filePath, 1024).compile.toList
         } yield contents
 

--- a/project/Tests.scala
+++ b/project/Tests.scala
@@ -6,7 +6,8 @@ object Tests extends AutoPlugin {
 
   override def buildSettings: Seq[Def.Setting[_]] = Seq(
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.2.5" % Test
+      "org.scalatest" %% "scalatest" % "3.2.5" % Test,
+      "org.scalatestplus" %% "scalacheck-1-15" % "3.2.5.0" % Test
     )
   )
 

--- a/project/Tests.scala
+++ b/project/Tests.scala
@@ -6,7 +6,7 @@ object Tests extends AutoPlugin {
 
   override def buildSettings: Seq[Def.Setting[_]] = Seq(
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.2.5" % Test,
+      "org.scalatest"     %% "scalatest"       % "3.2.5"   % Test,
       "org.scalatestplus" %% "scalacheck-1-15" % "3.2.5.0" % Test
     )
   )


### PR DESCRIPTION
Related to #333 

Seems it's working fine with cats.effect.IO, in my stacktrace you'll see I'm using ZIO as effect monad. Probably an issue there, will investigate