### PR TITLE
Fix S3 bug & write-read symmetry check

### DIFF
--- a/project/Tests.scala
+++ b/project/Tests.scala
@@ -6,7 +6,8 @@ object Tests extends AutoPlugin {
 
   override def buildSettings: Seq[Def.Setting[_]] = Seq(
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.2.6" % Test
+      "org.scalatest"     %% "scalatest"       % "3.2.6"   % Test,
+      "org.scalatestplus" %% "scalacheck-1-15" % "3.2.6.0" % Test
     )
   )
 


### PR DESCRIPTION
Moved symmetry check from #334 to `AbstractStoreTest`. 

Doing that also surfaced a bug in `S3Store`:  When writing empty byte stream to S3 without explicitly specifying size it didn't create a record at all. 