### PR TITLE
Make .stat result in URLs, not paths. Plus some minor URL changes.

### DIFF
--- a/box/src/main/scala/blobstore/box/BoxStore.scala
+++ b/box/src/main/scala/blobstore/box/BoxStore.scala
@@ -309,7 +309,7 @@ class BoxStore[F[_]: Async](
     * Input URLs to the returned store are validated against this Store's authority before the path is extracted and passed
     * to this store.
     */
-  override def lift(g: Url[String] => Validated[Throwable, Path.Plain]): Store[F, BoxPath] =
+  override def lift(g: Url.Plain => Validated[Throwable, Path.Plain]): Store[F, BoxPath] =
     new Store.DelegatingStore[F, BoxPath](this, g)
 
   override def transferTo[B, P, A](dstStore: Store[F, B], srcPath: Path[P], dstUrl: Url[A])(implicit

--- a/core/src/main/scala/blobstore/PathStore.scala
+++ b/core/src/main/scala/blobstore/PathStore.scala
@@ -92,10 +92,10 @@ abstract class PathStore[F[_], BlobType] {
     * Input URLs to the returned store are validated against this Store's authority before the path is extracted and passed
     * to this store.
     */
-  def lift(g: Url[String] => Validated[Throwable, Path.Plain]): Store[F, BlobType]
+  def lift(g: Url.Plain => Validated[Throwable, Path.Plain]): Store[F, BlobType]
 
   def lift: Store[F, BlobType] =
-    lift((u: Url[String]) => u.path.valid.map(_.plain))
+    lift((u: Url.Plain) => u.path.valid.map(_.plain))
 
   def transferTo[B, P, A](dstStore: Store[F, B], srcPath: Path[P], dstUrl: Url[A])(implicit ev: B <:< FsObject): F[Int]
 

--- a/core/src/main/scala/blobstore/StoreOps.scala
+++ b/core/src/main/scala/blobstore/StoreOps.scala
@@ -128,7 +128,7 @@ class StoreOps[F[_]: Files: Concurrent, B](store: Store[F, B]) {
     */
   def removeAll[A](url: Url[A])(implicit ev: B <:< FsObject): F[Int] = {
     val isDir = store.stat(url).compile.last.map {
-      case Some(d) => d.isDir
+      case Some(d) => d.path.isDir
       case None    => url.path.show.endsWith("/")
     }
 
@@ -138,7 +138,7 @@ class StoreOps[F[_]: Files: Concurrent, B](store: Store[F, B]) {
           if (u.path.isDir) {
             removeAll(url / u.path.lastSegment)
           } else {
-            val dUrl: Url[String] = if (isDir) url / u.path.lastSegment else url.replacePath(url.path)
+            val dUrl: Url.Plain = if (isDir) url / u.path.lastSegment else url.withPath(url.path.plain)
             store.remove(dUrl, recursive = false).as(1)
           }
         )

--- a/core/src/main/scala/blobstore/fs/FileStore.scala
+++ b/core/src/main/scala/blobstore/fs/FileStore.scala
@@ -106,7 +106,7 @@ class FileStore[F[_]: Files: Async] extends PathStore[F, NioPath] {
     * Input URLs to the returned store are validated against this Store's authority before the path is extracted and passed
     * to this store.
     */
-  override def lift(g: Url[String] => Validated[Throwable, Plain]): Store[F, NioPath] =
+  override def lift(g: Url.Plain => Validated[Throwable, Plain]): Store[F, NioPath] =
     new Store.DelegatingStore[F, NioPath](this, g)
 
   override def getContents[A](path: Path[A], chunkSize: Int): F[String] =

--- a/core/src/test/scala/blobstore/AbstractStoreTest.scala
+++ b/core/src/test/scala/blobstore/AbstractStoreTest.scala
@@ -158,6 +158,14 @@ abstract class AbstractStoreTest[B <: FsObject]
     io.unsafeRunSync()
   }
 
+  it should "stat urls" in {
+    val dir = dirUrl("list-dirs")
+    List("subdir/file-1.txt", "file-2.txt").map(writeFile(store, dir))
+
+    val b = store.stat(dir / "subdir" / "file-1.txt").compile.lastOrError.unsafeRunSync()
+    b.path.fileName mustBe Some("file-1.txt")
+  }
+
   it should "list files and directories correctly" in {
     val dir   = dirUrl("list-dirs")
     val paths = List("subdir/file-1.txt", "file-2.txt").map(writeFile(store, dir))
@@ -524,13 +532,13 @@ abstract class AbstractStoreTest[B <: FsObject]
     }
   }
 
-  def dirUrl(name: String): Url[String] = Url(scheme, authority, testRunRoot `//` name)
+  def dirUrl(name: String): Url.Plain = Url(scheme, authority, testRunRoot `//` name)
 
   def localDirPath(name: String): Path.Plain = transferStoreRootDir / name
 
   def contents(filename: String): String = s"file contents to upload: $filename"
 
-  def writeFile(store: Store[IO, B], tmpDir: Url[String])(filename: String): Url[String] = {
+  def writeFile(store: Store[IO, B], tmpDir: Url.Plain)(filename: String): Url.Plain = {
     def retry[AA](io: IO[AA], count: Int, times: Int): IO[AA] = io.handleErrorWith { t =>
       if (count < times) IO.sleep(500.millis) >> retry(io, count + 1, times) else IO.raiseError(t)
     }

--- a/core/src/test/scala/blobstore/StoreOpsTest.scala
+++ b/core/src/test/scala/blobstore/StoreOpsTest.scala
@@ -86,14 +86,14 @@ final case class DummyStore() extends Store[IO, String] {
       }
   }
   override def get[A](url: Url[A], chunkSize: Int): Stream[IO, Byte] = Stream.emits(buf)
-  override def list[A](url: Url[A], recursive: Boolean = false): Stream[IO, Url[String]] =
-    Stream.emits(List(url.replacePath(Path("the-file.txt"))))
+  override def list[A](url: Url[A], recursive: Boolean = false): Stream[IO, Url.Plain] =
+    Stream.emits(List(url.withPath(Path("the-file.txt"))))
   override def move[A, B](src: Url[A], dst: Url[B]): IO[Unit]                          = ???
   override def copy[A, B](src: Url[A], dst: Url[B]): IO[Unit]                          = ???
   override def remove[A](url: Url[A], recursive: Boolean): IO[Unit]                    = ???
   override def putRotate[A](computeUrl: IO[Url[A]], limit: Long): Pipe[IO, Byte, Unit] = ???
 
-  override def stat[A](url: Url[A]): Stream[IO, Path[String]] = ???
+  override def stat[A](url: Url[A]): Stream[IO, Url.Plain] = ???
 }
 
 object DummyStore {

--- a/core/src/test/scala/blobstore/fs/FileStoreTest.scala
+++ b/core/src/test/scala/blobstore/fs/FileStoreTest.scala
@@ -26,7 +26,7 @@ class FileStoreTest extends AbstractStoreTest[NioPath] {
   private val localStore: FileStore[IO] = FileStore[IO]
 
   override def mkStore(): Store[IO, NioPath] =
-    localStore.lift((u: Url[String]) => u.path.valid)
+    localStore.lift((u: Url.Plain) => u.path.valid)
 
   override val scheme: String       = "file"
   override val authority: Authority = Authority.localhost

--- a/gcs/src/main/scala/blobstore/gcs/GcsStore.scala
+++ b/gcs/src/main/scala/blobstore/gcs/GcsStore.scala
@@ -160,10 +160,10 @@ class GcsStore[F[_]: Async](
   override def copy[A, B](src: Url[A], dst: Url[B]): F[Unit] =
     Async[F].blocking(storage.copy(CopyRequest.of(GcsStore.toBlobId(src), GcsStore.toBlobId(dst))).getResult).void
 
-  override def stat[A](url: Url[A]): Stream[F, Path[GcsBlob]] =
+  override def stat[A](url: Url[A]): Stream[F, Url[GcsBlob]] =
     Stream.eval(Async[F].blocking(Option(storage.get(GcsStore.toBlobId(url)))))
       .unNone
-      .map(b => Path.of(b.getName, GcsBlob(b)))
+      .map(b => url.withPath(Path.of(b.getName, GcsBlob(b))))
 
 }
 

--- a/sftp/src/main/scala/blobstore/sftp/SftpStore.scala
+++ b/sftp/src/main/scala/blobstore/sftp/SftpStore.scala
@@ -201,9 +201,9 @@ class SftpStore[F[_]: Async] private (
       }
 
   override def lift: Store[F, SftpFile] =
-    lift((u: Url[String]) => u.path.relative.valid)
+    lift((u: Url.Plain) => u.path.relative.valid)
 
-  override def lift(g: Url[String] => Validated[Throwable, Plain]): Store[F, SftpFile] =
+  override def lift(g: Url.Plain => Validated[Throwable, Plain]): Store[F, SftpFile] =
     new Store.DelegatingStore[F, SftpFile](this, g)
 
   override def transferTo[B, P, A](dstStore: Store[F, B], srcPath: Path[P], dstUrl: Url[A])(implicit

--- a/url/src/test/scala/blobstore/url/HostTest.scala
+++ b/url/src/test/scala/blobstore/url/HostTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.Inside
 
+import scala.util.{Failure, Success, Try}
+
 class HostTest extends AnyFlatSpec with Matchers with Inside {
   behavior of "Host"
 
@@ -43,10 +45,21 @@ class HostTest extends AnyFlatSpec with Matchers with Inside {
         case Right(Hostname(_)) => //noop
       }
     }
+    validHostnames.map(Host.parseF[Try]).foreach { h =>
+      inside(h) {
+        case Success(Hostname(_)) => //noop
+      }
+    }
 
     validIps.map(Host.parse).map(_.toEither).foreach { h =>
       inside(h) {
         case Right(IpV4Address(_, _, _, _)) => //noop
+      }
+    }
+
+    validIps.map(Host.parseF[Try]).foreach { h =>
+      inside(h) {
+        case Success(IpV4Address(_, _, _, _)) => //noop
       }
     }
 
@@ -56,9 +69,21 @@ class HostTest extends AnyFlatSpec with Matchers with Inside {
       }
     }
 
+    invalidHostnames.map(Hostname.parseF[Try]).foreach { h =>
+      inside(h) {
+        case Failure(_) => //noop
+      }
+    }
+
     invalidIps.map(IpV4Address.parse).map(_.toEither).foreach { h =>
       inside(h) {
         case Left(_) => //noop
+      }
+    }
+
+    invalidIps.map(IpV4Address.parseF[Try]).foreach { h =>
+      inside(h) {
+        case Failure(_) => //noop
       }
     }
   }

--- a/url/src/test/scala/blobstore/url/HostnameTest.scala
+++ b/url/src/test/scala/blobstore/url/HostnameTest.scala
@@ -1,0 +1,55 @@
+package blobstore.url
+
+import cats.data.Validated.{Invalid, Valid}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.Inside
+
+import scala.util.{Failure, Success, Try}
+
+class HostnameTest extends AnyFlatSpec with Matchers with Inside {
+
+  behavior of "Hostname"
+
+  private val validHostnames = List(
+    "foo",
+    "foo-bar",
+    "FOOBAR",
+    "foo_bar",
+    "foo_bar123",
+    "a".repeat(63),
+    "a",
+    "A",
+    "foo.bar-baz"
+  )
+
+  val invalidHostnames = List(
+    "",
+    "f".repeat(64),
+    "foob#r".repeat(64)
+  )
+
+  it should "allow valid hostnames" in {
+    validHostnames.foreach { h =>
+      inside(Hostname.parse(h)) {
+        case Valid(_) => // noop
+      }
+
+      inside(Hostname.parseF[Try](h)) {
+        case Success(_) => // noop
+      }
+    }
+  }
+
+  it should "not allow invalid hostnames" in {
+    invalidHostnames.foreach { h =>
+      inside(Hostname.parse(h)) {
+        case Invalid(_) => // noop
+      }
+
+      inside(Hostname.parseF[Try](h)) {
+        case Failure(_) => // noop
+      }
+    }
+  }
+}


### PR DESCRIPTION
Also
* Add type alias for Url.Plain
* Default to rootless paths when parsing URLs. S3 and GCS fails on absolute path inputs, and SFTP in general works better with rootless paths. It seems like the better default.
* Add to{S3, Gcs, Sftp, …} utility methods on URL for easily convert between vendor URLs and reset path to `Path.Plain`
* Add some missing tests