### PR TITLE
Add carryforward flags to codecov configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         java: ['adopt:11']
     runs-on: ${{ matrix.os }}
     steps:
+      - id: scala-major-minor
+        run: |
+          v=$(echo ${{matrix.scala}} | cut -d'.' -f1-2)
+          echo "::set-output name=version::$v"
       - name: Checkout current branch (fast)
         uses: actions/checkout@v2
 
@@ -44,7 +48,7 @@ jobs:
       - name: Upload code coverage to codecov
         uses: codecov/codecov-action@v1
         with:
-          flags: local-scala-${{ matrix.scala }}
+          flags: local-scala-${{ steps.scala-major-minor.outputs.version }}
 
   all-test:
     name: Checks & all tests
@@ -56,6 +60,10 @@ jobs:
         java: ['adopt:11']
     runs-on: ${{ matrix.os }}
     steps:
+      - id: scala-major-minor
+        run: |
+          v=$(echo ${{matrix.scala}} | cut -d'.' -f1-2)
+          echo "::set-output name=version::$v"
       - name: Checkout current branch (fast)
         uses: actions/checkout@v2
 
@@ -80,4 +88,4 @@ jobs:
       - name: Upload code coverage to codecov
         uses: codecov/codecov-action@v1
         with:
-          flags: all-scala-${{ matrix.scala }}
+          flags: all-scala-${{ steps.scala-major-minor.outputs.version }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,5 +15,17 @@ coverage:
         informational: true
         if_ci_failed: success
 
+flags:
+  2.12:
+    paths:
+      - box/src/main/scala/blobstore/box/BoxPath.scala
+      - box/src/main/scala/blobstore/box/BoxStore.scala
+    carryforward: true
+  2.13:
+    paths:
+      - box/src/main/scala/blobstore/box/BoxPath.scala
+      - box/src/main/scala/blobstore/box/BoxStore.scala
+    carryforward: true
+
 ignore:
   - "**/S3MetaInfo.scala"


### PR DESCRIPTION
Enable Codecov's [carry forward flags](https://docs.codecov.io/docs/carryforward-flags). This enables proper coverage reports for partial test runs on PRs.