### PR TITLE
S3 multipart with know size and other fixes

### DIFF
--- a/core/src/main/scala/blobstore/StoreOps.scala
+++ b/core/src/main/scala/blobstore/StoreOps.scala
@@ -76,7 +76,7 @@ class StoreOps[F[_]: Files: Concurrent, B](store: Store[F, B]) {
   }
 
   /** getContents with default UTF8 decoder
-    * @param url Path to get
+    * @param url Url to get
     * @return F[String] with file contents
     */
   def getContents[A](url: Url[A], chunkSize: Int = 4096): F[String] = getContents(url, chunkSize, fs2.text.utf8Decode)
@@ -93,36 +93,29 @@ class StoreOps[F[_]: Files: Concurrent, B](store: Store[F, B]) {
     store.get(url, chunkSize).through(decoder).compile.toList.map(_.mkString)
 
   /** Collect all list results in the same order as the original list Stream
-    * @param url Path to list
-    * @return F\[List\[Path\]\] with all items in the result
+    * @param url Url to list
+    * @return F\[List\[Url\]\] with all items in the result
     */
-  def listAll[A](url: Url[A]): F[List[Url[B]]] =
-    store.list(url).compile.toList
+  def listAll[A](url: Url[A], recursive: Boolean = false): F[List[Url[B]]] =
+    store.list(url, recursive).compile.toList
 
   /** Copy value of the given path in this store to the destination store.
     *
-    * This is especially useful when transferring content into S3Store that requires to know content
-    * size before starting content upload.
-    *
-    * This method will list items from srcPath, get the file size and put into dstStore with the given size. If
-    * listing contents result in nested directories it will copy files inside dirs recursively.
+    * This method will list item at srcUrl and copy it to dstUrl in dstStore.
+    * If srcUrl points to a directory, it will copy files inside recursively.
     *
     * @param dstStore destination store
-    * @param srcUrl path to transfer from (can be a path to a file or dir)
-    * @param dstUrl path to transfer to (can be a path to a file or dir, if you are transferring multiple files,
-    *                make sure that dstPath.isDir == true, otherwise all files will override destination.
-    * @return Stream[F, Int] number of files transfered
+    * @param srcUrl url to transfer from (can be a path to a file or directory)
+    * @param dstUrl url to transfer to (if srcUrl points to a directory, interpreted as a prefix)
+    * @return F[Int] number of files transferred
     */
   def transferTo[BB, A, C](dstStore: Store[F, BB], srcUrl: Url[A], dstUrl: Url[C]): F[Int] =
-    store.list(srcUrl, recursive = true)
-      .flatMap(u =>
-        store.get(u, 4096)
-          .through(dstStore.put(dstUrl))
-          .last
-          .map(_.fold(0)(_ => 1))
-      )
-      .fold(0)(_ + _)
-      .compile.last.map(_.getOrElse(0))
+    store.list(srcUrl, recursive = true).evalMap { u =>
+      val targetUrl =
+        if (u.path.plain === srcUrl.path.plain) dstUrl.plain
+        else dstUrl / srcUrl.path.nioPath.relativize(u.path.nioPath).toString
+      store.get(u, 4096).through(dstStore.put(targetUrl)).compile.drain.as(1)
+    }.compile.fold(0)(_ + _)
 
   /** Remove all files from a store recursively, given a path
     */

--- a/gcs/build.sbt
+++ b/gcs/build.sbt
@@ -1,6 +1,6 @@
 name := "gcs"
 
 libraryDependencies ++= Seq(
-  "com.google.cloud" % "google-cloud-storage" % "1.115.0",
+  "com.google.cloud" % "google-cloud-storage" % "1.116.0",
   "com.google.cloud" % "google-cloud-nio"     % "0.123.2" % Test
 )

--- a/s3/src/main/scala/blobstore/s3/S3Store.scala
+++ b/s3/src/main/scala/blobstore/s3/S3Store.scala
@@ -17,11 +17,13 @@ package blobstore
 package s3
 
 import blobstore.url.{Path, Url}
-import cats.effect.std.{Hotswap, Queue}
-import cats.effect.{Async, Resource}
+import cats.effect.kernel.Resource.ExitCase
+import cats.effect.std.{Queue, Semaphore}
+import cats.effect.{Async, Ref, Resource}
 import cats.syntax.all._
-import fs2.{Chunk, INothing, Pipe, Pull, Stream}
+import fs2.{Chunk, Pipe, Pull, Stream}
 import fs2.interop.reactivestreams._
+import org.reactivestreams.Publisher
 import software.amazon.awssdk.core.async.{AsyncRequestBody, AsyncResponseTransformer, SdkPublisher}
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model._
@@ -29,6 +31,7 @@ import software.amazon.awssdk.services.s3.model._
 import java.nio.ByteBuffer
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
+import scala.util.Random
 
 /** @param s3 - S3 Async Client
   * @param objectAcl - optional default ACL to apply to all put, move and copy operations.
@@ -40,7 +43,7 @@ import scala.jdk.CollectionConverters._
   * @param defaultTrailingSlashFiles - test if folders returned by [[list]] are files with trailing slashes in their names.
   *                                  This controls behaviour of [[list]] method from Store trait.
   *                                  Use [[listUnderlying]] to control on per-invocation basis.
-  * @param bufferSize - size of buffer for multipart uploading (used for large streams without size known in advance).
+  * @param bufferSize – size of the buffer for multipart uploading (used for large streams without size known in advance).
   *                     @see https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
   */
 class S3Store[F[_]: Async](
@@ -52,10 +55,6 @@ class S3Store[F[_]: Async](
   bufferSize: Int = S3Store.multiUploadDefaultPartSize.toInt,
   queueSize: Int = 32
 ) extends Store[F, S3Blob] {
-  require(
-    bufferSize >= S3Store.multiUploadMinimumPartSize,
-    s"Buffer size must be at least ${S3Store.multiUploadMinimumPartSize}"
-  )
 
   override def list[A](url: Url[A], recursive: Boolean = false): Stream[F, Url[S3Blob]] =
     listUnderlying(url, defaultFullMetadata, defaultTrailingSlashFiles, recursive)
@@ -77,13 +76,13 @@ class S3Store[F[_]: Async](
   }
 
   private def performGet(request: GetObjectRequest) = {
-    val cf = new CompletableFuture[Stream[F, Byte]]()
-    val transformer: AsyncResponseTransformer[GetObjectResponse, Stream[F, Byte]] =
-      new AsyncResponseTransformer[GetObjectResponse, Stream[F, Byte]] {
-        override def prepare(): CompletableFuture[Stream[F, Byte]] = cf
-        override def onResponse(response: GetObjectResponse): Unit = ()
+    val cf = new CompletableFuture[Publisher[ByteBuffer]]()
+    val transformer: AsyncResponseTransformer[GetObjectResponse, Publisher[ByteBuffer]] =
+      new AsyncResponseTransformer[GetObjectResponse, Publisher[ByteBuffer]] {
+        override def prepare(): CompletableFuture[Publisher[ByteBuffer]] = cf
+        override def onResponse(response: GetObjectResponse): Unit       = ()
         override def onStream(publisher: SdkPublisher[ByteBuffer]): Unit = {
-          cf.complete(publisher.toStream.flatMap(bb => Stream.chunk(Chunk.byteBuffer(bb))))
+          cf.complete(publisher)
           ()
         }
         override def exceptionOccurred(error: Throwable): Unit = {
@@ -92,8 +91,8 @@ class S3Store[F[_]: Async](
         }
       }
     Stream.eval(
-      Async[F].fromCompletableFuture(Async[F].delay(s3.getObject[Stream[F, Byte]](request, transformer)))
-    ).flatten
+      Async[F].fromCompletableFuture(Async[F].delay(s3.getObject(request, transformer)))
+    ).flatMap(publisher => publisher.toStream.flatMap(bb => Stream.chunk(Chunk.byteBuffer(bb))))
   }
 
   def put[A](url: Url[A], overwrite: Boolean = true, size: Option[Long] = None): Pipe[F, Byte, Unit] =
@@ -122,8 +121,7 @@ class S3Store[F[_]: Async](
             }
         } else Async[F].unit
 
-      Stream.eval(checkOverwrite) ++
-        size.fold(putUnknownSize(bucket, key, meta, in))(size => putKnownSize(bucket, key, meta, size, in))
+      Stream.eval(checkOverwrite) ++ putUnderlying(bucket, key, meta, size, in)
     }
 
   override def move[A, B](src: Url[A], dst: Url[B]): F[Unit] =
@@ -162,23 +160,19 @@ class S3Store[F[_]: Async](
     else Async[F].fromCompletableFuture(Async[F].delay(s3.deleteObject(req))).void
   }
 
-  override def putRotate[A](computeUrl: F[Url[A]], limit: Long): Pipe[F, Byte, Unit] =
-    if (limit <= bufferSize.toLong) {
-      _.chunkN(limit.toInt)
-        .flatMap(chunk => Stream.eval(computeUrl).flatMap(path => Stream.chunk(chunk).through(put(path))))
-    } else {
-      val newFile = for {
-        path  <- Resource.eval(computeUrl)
-        queue <- Resource.eval(Queue.bounded[F, Option[Chunk[Byte]]](queueSize))
-        _ <- Resource.make(
-          Async[F].start(
-            Stream.fromQueueNoneTerminatedChunk(queue).through(put(path)).compile.drain
-          )
-        )(_.join.flatMap(_.fold(Async[F].unit, e => Async[F].raiseError[Unit](e), identity)))
-        _ <- Resource.make(Async[F].unit)(_ => queue.offer(None))
-      } yield queue
-      putRotateBase(limit, newFile)(queue => chunk => queue.offer(Some(chunk)))
-    }
+  override def putRotate[A](computeUrl: F[Url[A]], limit: Long): Pipe[F, Byte, Unit] = {
+    val newFile = for {
+      path  <- Resource.eval(computeUrl)
+      queue <- Resource.eval(Queue.bounded[F, Option[Chunk[Byte]]](queueSize))
+      _ <- Resource.make(
+        Async[F].start(
+          Stream.fromQueueNoneTerminatedChunk(queue).through(put(path)).compile.drain
+        )
+      )(_.join.flatMap(_.fold(Async[F].unit, e => Async[F].raiseError[Unit](e), identity)))
+      _ <- Resource.make(Async[F].unit)(_ => queue.offer(None))
+    } yield queue
+    putRotateBase(limit, newFile)(queue => chunk => queue.offer(Some(chunk)))
+  }
 
   def listUnderlying[A](
     url: Url[A],
@@ -235,138 +229,178 @@ class S3Store[F[_]: Async](
     }
   }
 
-  private def putKnownSize(
+  private def putSingle(
     bucket: String,
     key: String,
     meta: Option[S3MetaInfo],
-    size: Long,
+    bytes: Array[Byte]
+  ): F[Unit] = {
+    val request     = S3Store.putObjectRequest(sseAlgorithm, objectAcl)(bucket, key, meta, bytes.length.toLong)
+    val requestBody = AsyncRequestBody.fromBytes(bytes)
+    Async[F].fromCompletableFuture(Async[F].delay(s3.putObject(request, requestBody))).void
+  }
+
+  private def putMultiPart(
+    bucket: String,
+    key: String,
+    meta: Option[S3MetaInfo],
+    maybeSize: Option[Long],
     in: Stream[F, Byte]
-  ): Stream[F, Unit] =
-    Stream.resource(in.chunks.map(chunk => ByteBuffer.wrap(chunk.toArray)).toUnicastPublisher).flatMap { publisher =>
-      val request = S3Store.putObjectRequest(sseAlgorithm, objectAcl)(bucket, key, meta, size)
-
-      val requestBody = AsyncRequestBody.fromPublisher(publisher)
-
-      Stream.eval(Async[F].fromCompletableFuture(Async[F].delay(s3.putObject(request, requestBody))).void)
+  ): Stream[F, Unit] = {
+    val request: CreateMultipartUploadRequest = {
+      val builder = CreateMultipartUploadRequest.builder()
+      val withAcl = objectAcl.fold(builder)(builder.acl)
+      val withSSE = sseAlgorithm.fold(withAcl)(withAcl.serverSideEncryption)
+      meta
+        .fold(withSSE)(S3MetaInfo.createMultipartUploadRequest(withSSE))
+        .bucket(bucket)
+        .key(key)
+        .build()
     }
 
-  private def putSingleChunk(
-    bucket: String,
-    key: String,
-    meta: Option[S3MetaInfo],
-    chunk: Chunk[Byte]
-  ): Pull[F, INothing, Unit] =
-    Pull.eval(Async[F].fromCompletableFuture(Async[F].delay(s3.putObject(
-      S3Store.putObjectRequest(sseAlgorithm, objectAcl)(bucket, key, meta, chunk.size.toLong),
-      AsyncRequestBody.fromBytes(chunk.toArray)
-    ))).void)
+    val makeRequest: F[CreateMultipartUploadResponse] =
+      Async[F].fromCompletableFuture(Async[F].delay(s3.createMultipartUpload(request)))
 
-  private def putUnknownSize(
-    bucket: String,
-    key: String,
-    meta: Option[S3MetaInfo],
-    in: Stream[F, Byte]
-  ): Stream[F, Unit] =
-    in.pull
-      .unconsN(bufferSize, allowFewer = true)
-      .flatMap {
-        case None =>
-          putSingleChunk(bucket, key, meta, Chunk.empty)
-        case Some((chunk, _)) if chunk.size < bufferSize =>
-          putSingleChunk(bucket, key, meta, chunk)
-        case Some((chunk, rest)) =>
-          val request: CreateMultipartUploadRequest = {
-            val builder = CreateMultipartUploadRequest.builder()
-            val withAcl = objectAcl.fold(builder)(builder.acl)
-            val withSSE = sseAlgorithm.fold(withAcl)(withAcl.serverSideEncryption)
-            meta
-              .fold(withSSE)(S3MetaInfo.createMultipartUploadRequest(withSSE))
-              .bucket(bucket)
-              .key(key)
-              .build()
+    Stream.eval((makeRequest, Semaphore(2)).tupled).flatMap { case (muResp, semaphore) =>
+      val uploadPartReqBuilder: UploadPartRequest.Builder = meta
+        .fold(UploadPartRequest.builder())(S3MetaInfo.uploadPartRequest)
+        .bucket(bucket)
+        .key(key)
+        .uploadId(muResp.uploadId())
+
+      val partRef                                        = Ref.unsafe(1)
+      val completedPartsRef: Ref[F, List[CompletedPart]] = Ref.unsafe(Nil)
+
+      val pipe: Pipe[F, Byte, Unit] = maybeSize match {
+        case Some(size) =>
+          // TODO: Do something better than this
+          val arbitraryGuess =
+            if (bufferSize == S3Store.multiUploadDefaultPartSize) {
+              size / (1 + Random.nextInt(31))
+            } else bufferSize.toLong
+          val partSize =
+            arbitraryGuess.max(S3Store.multiUploadMinimumPartSize).min(S3Store.multiUploadDefaultPartSize)
+          val totalParts   = (size.toDouble / partSize).ceil.toInt
+          val lastPartSize = size - ((totalParts - 1) * partSize)
+          val resource = for {
+            part <- Resource.eval(partRef.getAndUpdate(_ + 1))
+            _ <- Resource.eval(if (part > totalParts)
+              new IllegalArgumentException("Provided size doesn't match evaluated stream length.").raiseError
+            else Async[F].unit)
+            queue     <- Resource.eval(Queue.bounded[F, Option[ByteBuffer]](queueSize))
+            publisher <- Stream.fromQueueNoneTerminated(queue).toUnicastPublisher
+            _ <- Resource.make(
+              Async[F].start(
+                Async[F].fromCompletableFuture(Async[F].delay {
+                  s3.uploadPart(
+                    uploadPartReqBuilder
+                      .partNumber(part)
+                      .contentLength(if (part == totalParts) lastPartSize else partSize)
+                      .build(),
+                    AsyncRequestBody.fromPublisher(publisher)
+                  )
+                })
+              )
+            )(_.joinWithNever.flatMap(resp =>
+              completedPartsRef.update(CompletedPart.builder().eTag(resp.eTag()).partNumber(part).build() :: _)
+            ))
+            _ <- Resource.make(Async[F].unit)(_ => queue.offer(None))
+          } yield queue
+
+          if (totalParts > S3Store.maxMultipartParts) {
+            _ => Stream.raiseError(S3Store.multipartUploadPartsError)
+          } else {
+            putRotateBase(partSize, resource) { queue => chunk =>
+              queue.offer(Some(ByteBuffer.wrap(chunk.toArray)))
+            }
           }
+        case None =>
+          lazy val directBuffers = (
+            ByteBuffer.allocateDirect(bufferSize),
+            ByteBuffer.allocateDirect(bufferSize)
+          )
 
-          val makeRequest: F[CreateMultipartUploadResponse] =
-            Async[F].fromCompletableFuture(Async[F].delay(s3.createMultipartUpload(request)))
+          def selectBuffer(part: Int) = if (part % 2 == 0) directBuffers._1 else directBuffers._2
 
-          Pull.eval(makeRequest).flatMap { muResp =>
-            val abortReq: AbortMultipartUploadRequest =
-              AbortMultipartUploadRequest.builder().bucket(bucket).key(key).uploadId(muResp.uploadId()).build()
-            val uploadPartReqBuilder: UploadPartRequest.Builder = meta
-              .fold(UploadPartRequest.builder())(S3MetaInfo.uploadPartRequest)
-              .bucket(bucket)
-              .key(key)
-              .contentLength(bufferSize.toLong)
-              .uploadId(muResp.uploadId())
-            val completeReqBuilder = CompleteMultipartUploadRequest
+          def acquireBuffer(part: Int) = for {
+            _ <- semaphore.acquire
+            _ <- Async[F].blocking {
+              selectBuffer(part).clear()
+            }
+          } yield ()
+
+          val resource = for {
+            part <- Resource.eval(partRef.getAndUpdate(_ + 1))
+            _    <- Resource.eval(acquireBuffer(part))
+            _ <- Resource.eval {
+              if (part > S3Store.maxMultipartParts) S3Store.multipartUploadPartsError.raiseError
+              else Async[F].unit
+            }
+            _ <- Resource.onFinalize(semaphore.release)
+            _ <- Resource.onFinalize {
+              Async[F].fromCompletableFuture(Async[F].delay {
+                s3.uploadPart(
+                  uploadPartReqBuilder.partNumber(part).build(),
+                  AsyncRequestBody.fromByteBuffer(selectBuffer(part).flip())
+                )
+              }).flatMap { resp =>
+                completedPartsRef.update(CompletedPart.builder().eTag(resp.eTag()).partNumber(part).build() :: _)
+              }
+            }
+          } yield selectBuffer(part)
+
+          if (bufferSize < S3Store.multiUploadMinimumPartSize) {
+            _ => Stream.raiseError(S3Store.multipartUploadBufferTooSmallError)
+          } else if (bufferSize > S3Store.multiUploadDefaultPartSize) {
+            _ => Stream.raiseError(S3Store.multipartUploadBufferTooLargeError)
+          } else {
+            putRotateBase(bufferSize.toLong, resource)(bb => chunk => Async[F].blocking(bb.put(chunk.toArray)).void)
+          }
+      }
+
+      in.through(pipe).onFinalizeCase {
+        case ExitCase.Succeeded =>
+          completedPartsRef.get.flatMap { parts =>
+            val req = CompleteMultipartUploadRequest
               .builder()
               .bucket(bucket)
               .key(key)
               .uploadId(muResp.uploadId())
+              .multipartUpload(CompletedMultipartUpload.builder().parts(parts.reverse.asJava).build())
+              .build()
 
-            val byteBuffer = ByteBuffer.allocateDirect(bufferSize)
-
-            def mkNewPartResource(part: Int, size: Option[Long] = None): Resource[F, F[CompletedPart]] =
-              Resource
-                .makeCase {
-                  val cf       = new CompletableFuture[ByteBuffer]()
-                  val withPart = uploadPartReqBuilder.partNumber(part)
-                  val req      = size.fold(withPart)(newSize => withPart.contentLength(newSize)).build()
-                  val fBody    = Async[F].delay(AsyncRequestBody.fromPublisher(CompletableFuturePublisher.from(cf)))
-                  val done = for {
-                    body <- fBody
-                    resp <- Async[F].fromCompletableFuture(Async[F].delay(s3.uploadPart(req, body)))
-                    _    <- Async[F].delay(byteBuffer.clear())
-                  } yield CompletedPart.builder().eTag(resp.eTag()).partNumber(part).build()
-                  Async[F].delay((cf, done))
-                } {
-                  case ((cf, _), Resource.ExitCase.Succeeded) =>
-                    Async[F].delay { byteBuffer.flip(); cf.complete(byteBuffer) }.void
-                  case ((cf, _), Resource.ExitCase.Errored(e)) =>
-                    Async[F].delay(cf.completeExceptionally(e)).void
-                  case ((cf, _), Resource.ExitCase.Canceled) =>
-                    Async[F].delay(cf.cancel(true)).void
-                }
-                .map(_._2)
-
-            Stream
-              .resource(Hotswap(mkNewPartResource(1)))
-              .pull
-              .headOrError
-              .flatMap {
-                case (hotswap, completion) =>
-                  Pull
-                    .eval(
-                      S3Store
-                        .multipartGo(
-                          S3Store.MultipartState(1, 0L),
-                          rest.cons(chunk),
-                          byteBuffer,
-                          completion,
-                          hotswap,
-                          mkNewPartResource
-                        )
-                        .stream
-                        .compile
-                        .toList
-                    )
-                    .flatMap { parts =>
-                      val request =
-                        completeReqBuilder
-                          .multipartUpload(CompletedMultipartUpload.builder().parts(parts.asJava).build())
-                          .build()
-                      Pull.eval(
-                        Async[F].fromCompletableFuture(Async[F].delay(s3.completeMultipartUpload(request)))
-                      ).void
-                    }
-              }
-              .onError {
-                case _ =>
-                  Pull.eval(Async[F].fromCompletableFuture(Async[F].delay(s3.abortMultipartUpload(abortReq)))).void
-              }
+            Async[F].fromCompletableFuture(Async[F].delay(s3.completeMultipartUpload(req))).void
           }
+        case _ =>
+          val req = AbortMultipartUploadRequest.builder().bucket(bucket).key(key).uploadId(muResp.uploadId()).build()
+          Async[F].fromCompletableFuture(Async[F].delay(s3.abortMultipartUpload(req))).void
       }
-      .stream
+    }
+  }
+
+  private def putUnderlying(
+    bucket: String,
+    key: String,
+    meta: Option[S3MetaInfo],
+    maybeSize: Option[Long],
+    in: Stream[F, Byte]
+  ): Stream[F, Unit] = {
+    maybeSize match {
+      case None =>
+        in.pull.unconsN(S3Store.multiUploadMinimumPartSize.toInt, allowFewer = true).flatMap {
+          case None =>
+            Pull.eval(putSingle(bucket, key, meta, Array.emptyByteArray))
+          case Some((chunk, _)) if chunk.size < S3Store.multiUploadMinimumPartSize.toInt =>
+            Pull.eval(putSingle(bucket, key, meta, chunk.toArray))
+          case Some((chunk, rest)) =>
+            Pull.eval(putMultiPart(bucket, key, meta, none, rest.consChunk(chunk)).compile.drain)
+        }.stream
+      case Some(size) if size <= S3Store.multiUploadThreshold =>
+        Stream.eval(in.compile.to(Array).flatMap(bytes => putSingle(bucket, key, meta, bytes = bytes)))
+      case size =>
+        putMultiPart(bucket, key, meta, size, in)
+    }
+  }
 
   override def stat[A](url: Url[A]): Stream[F, Url[S3Blob]] =
     Stream.eval(Async[F].fromCompletableFuture(Async[F].delay(
@@ -412,19 +446,15 @@ object S3Store {
     defaultTrailingSlashFiles: Boolean = false,
     bufferSize: Int = S3Store.multiUploadDefaultPartSize.toInt,
     queueSize: Int = 32
-  ): F[S3Store[F]] =
-    if (bufferSize < S3Store.multiUploadMinimumPartSize) {
-      new IllegalArgumentException(s"Buffer size must be at least ${S3Store.multiUploadMinimumPartSize}").raiseError
-    } else
-      new S3Store(
-        s3,
-        objectAcl,
-        sseAlgorithm,
-        defaultFullMetadata,
-        defaultTrailingSlashFiles,
-        bufferSize,
-        queueSize
-      ).pure[F]
+  ): S3Store[F] = new S3Store(
+    s3,
+    objectAcl,
+    sseAlgorithm,
+    defaultFullMetadata,
+    defaultTrailingSlashFiles,
+    bufferSize,
+    queueSize
+  )
 
   private def putObjectRequest(
     sseAlgorithm: Option[String],
@@ -446,75 +476,19 @@ object S3Store {
   /** @see https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
     */
   private val multiUploadMinimumPartSize: Long = 5L * mb
+  private val multiUploadThreshold: Long       = 100L * mb
   private val multiUploadDefaultPartSize: Long = 500L * mb
-  private val maxTotalSize: Long               = 5000000L * mb
+  private val maxMultipartParts: Int           = 10000
 
-  private case class MultipartState(partNumber: Int, totalBytes: Long)
+  private val multipartUploadPartsError = new IllegalArgumentException(
+    s"S3 doesn't support multipart uploads with more than ${S3Store.maxMultipartParts} parts."
+  )
 
-  private def multipartGo[F[_]: Async](
-    state: MultipartState,
-    stream: Stream[F, Byte],
-    byteBuffer: ByteBuffer,
-    completion: F[CompletedPart],
-    hotswap: Hotswap[F, F[CompletedPart]],
-    newPart: (Int, Option[Long]) => Resource[F, F[CompletedPart]]
-  ): Pull[F, CompletedPart, Unit] = {
-    stream.pull.unconsLimit(byteBuffer.capacity() - byteBuffer.position()).flatMap {
-      case Some((hd, tl)) =>
-        val newTotal = state.totalBytes + hd.size
-        if (newTotal > maxTotalSize) {
-          Pull.raiseError(
-            new IllegalArgumentException(
-              s"S3 doesn't support files larger than 5 TB, stream has at least $newTotal bytes"
-            )
-          )
-        } else {
-          Pull
-            .eval(Async[F].delay(byteBuffer.put(hd.toArray)))
-            .flatMap { _ =>
-              if (byteBuffer.position() < byteBuffer.capacity()) {
-                multipartGo(
-                  state.copy(totalBytes = newTotal),
-                  stream = tl,
-                  byteBuffer = byteBuffer,
-                  completion = completion,
-                  hotswap = hotswap,
-                  newPart = newPart
-                )
-              } else {
-                Pull
-                  .eval(hotswap.swap(newPart(state.partNumber + 1, None)))
-                  .flatMap { newCompletion =>
-                    Pull.eval(completion).flatMap { cp =>
-                      Pull.output1[F, CompletedPart](cp) >>
-                        multipartGo(
-                          MultipartState(state.partNumber + 1, newTotal),
-                          stream = tl,
-                          byteBuffer = byteBuffer,
-                          completion = newCompletion,
-                          hotswap = hotswap,
-                          newPart = newPart
-                        )
-                    }
-                  }
-              }
-            }
-        }
-      case None =>
-        val currentBytes = byteBuffer.position()
-        if (currentBytes > 0) {
-          Pull
-            .eval(
-              hotswap
-                .swap(newPart(state.partNumber, Some(currentBytes.toLong)))
-                .flatMap { newCompletion =>
-                  hotswap.clear >> Async[F].delay(byteBuffer.limit(currentBytes)) >> newCompletion
-                }
-            )
-            .flatMap(Pull.output1)
-        } else {
-          Pull.done
-        }
-    }
-  }
+  private val multipartUploadBufferTooSmallError = new IllegalArgumentException(
+    s"Please use buffer size of at least 5Mb – S3 requires minimal size of 5Mb per part of multipart upload."
+  )
+
+  private val multipartUploadBufferTooLargeError = new IllegalArgumentException(
+    s"Please use buffer size less than 500Mb – S3 requires maximum object size of 5Tb, and maximum number of 10000 parts in multipart upload."
+  )
 }

--- a/url/src/main/scala/blobstore/url/Host.scala
+++ b/url/src/main/scala/blobstore/url/Host.scala
@@ -75,8 +75,10 @@ object IpV4Address {
     case Invalid(e) => throw MultipleUrlValidationException(e) // scalafix:ok
   }
 
+  private def intOctets(ip: IpV4Address) = (ip.octet1 & 0xff, ip.octet2 & 0xff, ip.octet3 & 0xff, ip.octet4 & 0xff)
+
   def compare(x: IpV4Address, y: IpV4Address): Int =
-    x.bytes.toList.zip(y.bytes.toList).map(((_: Byte) - (_: Byte)).tupled).find(_ != 0).getOrElse(0)
+    intOctets(x) compare intOctets(y)
 
   implicit val ordering: Ordering[IpV4Address] = compare
   implicit val order: Order[IpV4Address]       = Order.fromOrdering[IpV4Address]


### PR DESCRIPTION
- Fix multipart upload to S3 with known size – this prevented uploading object bigger than 5Gb with known size.
- Extract small fixes from #389

Closes #424