### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     needs: [scalafmt]
     strategy:
       matrix:
-        scala: [ 2.12.14, 2.13.6, 3.0.2 ]
+        scala: [ 2.12.15, 2.13.7, 3.1.0 ]
     steps:
       - name: Checkout current branch (fast)
         uses: actions/checkout@v2.4.0
@@ -63,11 +63,11 @@ jobs:
         run: mkdir tmp
 
       - name: Test with coverage
-        if: ${{ matrix.scala != '3.0.2' }}
+        if: ${{ matrix.scala != '3.1.0' }}
         run: sbt ++${{ matrix.scala }} '; coverage ; testOnly * -- -l blobstore.IntegrationTest'
 
       - name: Test without coverage
-        if: ${{ matrix.scala == '3.0.2' }}
+        if: ${{ matrix.scala == '3.1.0' }}
         run: sbt ++${{ matrix.scala }} 'testOnly * -- -l blobstore.IntegrationTest'
 
       - name: Publish JUnit test report
@@ -78,7 +78,7 @@ jobs:
           report_paths: '**/target/test-reports/*.xml'
 
       - name: Generate coverage report
-        if: ${{ matrix.scala != '3.0.2' }}
+        if: ${{ matrix.scala != '3.1.0' }}
         run: sbt ++${{ matrix.scala }} coverageReport
 
       - name: Upload code coverage to codecov

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.1.1"
+version = "3.1.2"
 runner.dialect = scala3
 project.git = true
 maxColumn = 120                                 // Column width

--- a/azure/build.sbt
+++ b/azure/build.sbt
@@ -1,6 +1,6 @@
 name := "azure"
 
-val fs2Version = "3.1.6"
+val fs2Version = "3.2.4"
 
 libraryDependencies ++= Seq(
   "com.azure"     % "azure-storage-blob"        % "12.14.2",

--- a/box/build.sbt
+++ b/box/build.sbt
@@ -1,5 +1,5 @@
 name := "box"
 
 libraryDependencies ++= Seq(
-  "com.box" % "box-java-sdk" % "2.57.0"
+  "com.box" % "box-java-sdk" % "2.58.0"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,16 @@
-inThisBuild(
-  Seq(
-    scalaVersion       := "2.13.6",
-    crossScalaVersions := Seq("2.12.15", "2.13.6", "3.0.2"),
-    organization       := "com.github.fs2-blobstore",
-    licenses           := List("Apache-2.0" -> sbt.url("http://www.apache.org/licenses/LICENSE-2.0")),
-    developers := List(
-      Developer("rolandomanrique", "Rolando Manrique", "", sbt.url("http://github.com/rolandomanrique")),
-      Developer("stew", "Stew O'Connor", "", sbt.url("https://github.com/stew")),
-      Developer("gafiatulin", "Victor Gafiatulin", "", sbt.url("https://github.com/gafiatulin")),
-      Developer("jgogstad", "Jostein Gogstad", "", sbt.url("https://github.com/jgogstad"))
-    ),
-    homepage  := Some(sbt.url("https://github.com/fs2-blobstore/fs2-blobstore")),
-    startYear := Some(2018),
-    javacOptions ++= Seq("--release", "8")
-  )
+ThisBuild / scalaVersion       := "2.13.7"
+ThisBuild / crossScalaVersions := Seq("2.12.15", "2.13.7", "3.1.0")
+ThisBuild / organization       := "com.github.fs2-blobstore"
+ThisBuild / licenses           := List("Apache-2.0" -> sbt.url("http://www.apache.org/licenses/LICENSE-2.0"))
+ThisBuild / developers := List(
+  Developer("rolandomanrique", "Rolando Manrique", "", sbt.url("http://github.com/rolandomanrique")),
+  Developer("stew", "Stew O'Connor", "", sbt.url("https://github.com/stew")),
+  Developer("gafiatulin", "Victor Gafiatulin", "", sbt.url("https://github.com/gafiatulin")),
+  Developer("jgogstad", "Jostein Gogstad", "", sbt.url("https://github.com/jgogstad"))
 )
+ThisBuild / homepage  := Some(sbt.url("https://github.com/fs2-blobstore/fs2-blobstore"))
+ThisBuild / startYear := Some(2018)
+ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 lazy val fs2blobstore = project
   .in(file("."))

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,6 +1,6 @@
 name := "core"
 
-val fs2Version = "3.1.6"
+val fs2Version = "3.2.4"
 
 libraryDependencies ++= Seq(
   "co.fs2" %% "fs2-core" % fs2Version,

--- a/gcs/build.sbt
+++ b/gcs/build.sbt
@@ -1,6 +1,6 @@
 name := "gcs"
 
 libraryDependencies ++= Seq(
-  "com.google.cloud" % "google-cloud-storage" % "2.2.1",
-  "com.google.cloud" % "google-cloud-nio"     % "0.123.16" % Test
+  "com.google.cloud" % "google-cloud-storage" % "2.2.2",
+  "com.google.cloud" % "google-cloud-nio"     % "0.123.17" % Test
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scoverage"             % "sbt-scoverage"  % "1.9.2")
 addSbtPlugin("com.github.sbt"            % "sbt-ci-release" % "1.5.10")
-addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"   % "0.9.32")
+addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"   % "0.9.33")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"   % "0.1.20")
 addSbtPlugin("org.scalameta"             % "sbt-mdoc"       % "2.2.24")

--- a/s3/build.sbt
+++ b/s3/build.sbt
@@ -1,9 +1,9 @@
 name := "s3"
 
-val fs2Version = "3.1.6"
+val fs2Version = "3.2.4"
 
 libraryDependencies ++= Seq(
-  "software.amazon.awssdk" % "s3"                        % "2.17.83",
+  "software.amazon.awssdk" % "s3"                        % "2.17.103",
   "co.fs2"                %% "fs2-reactive-streams"      % fs2Version,
   "com.dimafeng"          %% "testcontainers-scala-core" % "0.39.12" % Test
 )

--- a/sftp/build.sbt
+++ b/sftp/build.sbt
@@ -1,6 +1,6 @@
 name := "sftp"
 
 libraryDependencies ++= Seq(
-  "com.github.mwiede" % "jsch"                      % "0.1.70",
+  "com.github.mwiede" % "jsch"                      % "0.1.72",
   "com.dimafeng"     %% "testcontainers-scala-core" % "0.39.12" % Test
 )

--- a/url/build.sbt
+++ b/url/build.sbt
@@ -1,7 +1,7 @@
 name := "url"
 
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-core" % "2.6.1"
+  "org.typelevel" %% "cats-core" % "2.7.0"
 ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
   case Some((2, x)) if x < 13 =>
     "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0" :: Nil

--- a/url/src/test/scala/blobstore/url/HostnameTest.scala
+++ b/url/src/test/scala/blobstore/url/HostnameTest.scala
@@ -17,7 +17,7 @@ class HostnameTest extends AnyFlatSpec with Matchers with Inside {
     "FOOBAR",
     "foo_bar",
     "foo_bar123",
-    "a".repeat(63),
+    "a" * 63,
     "a",
     "A",
     "foo.bar-baz"
@@ -25,8 +25,8 @@ class HostnameTest extends AnyFlatSpec with Matchers with Inside {
 
   val invalidHostnames = List(
     "",
-    "f".repeat(64),
-    "foob#r".repeat(64)
+    "f" * 64,
+    "foob#r" * 64
   )
 
   it should "allow valid hostnames" in {


### PR DESCRIPTION
This updates Scala3 to 3.1.0, which is transitively required by fs2 3.2.x: https://github.com/typelevel/fs2/releases/tag/v3.2.0